### PR TITLE
fix behavior with units

### DIFF
--- a/src/HChebInterp.jl
+++ b/src/HChebInterp.jl
@@ -328,7 +328,7 @@ function hchebinterp(f::BatchFunction, a::SVector{n,T}, b::SVector{n,T}; criteri
         BatchFunction(t -> f.f(map!(t2x, x, t)), ts)
     else
         @assert size(f.x) == size(ts)
-        BatchFunction(t -> f.f(map!(t2x, reinterpret(SVector{n,T}, f.x), t)), ts)
+        BatchFunction(t -> f.f(map!(t2x, f.x, t)), ts)
     end
     p = hchebinterp_(criterion, g, -e, e, ord, atol, rtol, norm, maxevals, initdiv, droptol)
     return TreePoly(p.valtree, p.funtree, p.searchtree, a, b, p.initdiv)
@@ -339,7 +339,7 @@ function hchebinterp(f, a, b; kws...)
     T = float(promote_type(eltype(a),eltype(b)))
     g = if a isa Number
         if f isa BatchFunction
-            BatchFunction(x -> f.f(reinterpret(T, x)), f.x)
+            BatchFunction(x -> f.f(reinterpret(T, x)), reinterpret(SVector{n,T}, f.x))
         else
             BatchFunction(x -> f.(reinterpret(T, x)))
         end

--- a/src/HChebInterp.jl
+++ b/src/HChebInterp.jl
@@ -39,8 +39,8 @@ end
 
 # x = a + (1+t)*(b-a)/2, t∈[-1,1]
 # t = (x-a)*2/(b-a) - 1, x∈[a,b]
-function (p::TreePoly{N,T,V,Td,Tx})(x) where {N,T,V,Td,Tx}
-    t = map((a, b, x) -> (x-a)*2/(b-a)-1, p.lb, p.ub, SVector{N,Tx}(x))
+function (p::TreePoly{N,T,V,Td,Tx})(x::SVector{N,Tx}) where {N,T,V,Td,Tx}
+    t = map((a, b, x) -> (x-a)*2/(b-a)-1, p.lb, p.ub, x)
     for i in 1:p.initdiv^N
         fun = p.funtree[i]
         children = p.searchtree[i]
@@ -57,6 +57,7 @@ function (p::TreePoly{N,T,V,Td,Tx})(x) where {N,T,V,Td,Tx}
     end
     throw(ArgumentError("$x not in domain $(p.lb) to $(p.ub)"))
 end
+(p::TreePoly{N,T,V,Td,Tx})(x) where {N,T,V,Td,Tx} = p(SVector{N,Tx}(x))
 
 # chebpoint does not use precision of endpoints in current release v1.2
 function _chebpoint(i::CartesianIndex{N}, order::NTuple{N,Int}, lb::SVector{N}, ub::SVector{N}) where {N}

--- a/src/HChebInterp.jl
+++ b/src/HChebInterp.jl
@@ -324,7 +324,7 @@ function hchebinterp(f::BatchFunction, a::SVector{n,T}, b::SVector{n,T}; criteri
     ord = fill_ntuple(order, n)
     t = Array{typeof(e),n}(undef, ord .+ 1)
     x = isnothing(f.x) ? similar(t, typeof(a)) : f.x
-    @assert size(x) == size(ts)
+    @assert size(x) == size(t)
     g = BatchFunction(t -> f.f(map!(t2x, x, t)), t)
     p = hchebinterp_(criterion, g, -e, e, ord, atol, rtol, norm, maxevals, initdiv, droptol)
     return TreePoly(p.valtree, p.funtree, p.searchtree, a, b, p.initdiv)

--- a/test/units.jl
+++ b/test/units.jl
@@ -1,9 +1,10 @@
-using Test, Unitful, HChebInterp
+using Test, Unitful, HChebInterp, StaticArrays
 
 f1 = x -> x^3 - sin(x)
 uf1 = x -> f1(x/oneunit(x))
 fun1 = hchebinterp(uf1, 0.0u"m", 1.0u"m")
 @test uf1(0.5u"m") ≈ fun1(0.5u"m")
+@test uf1(0.5u"m") ≈ fun1(5e5u"μm")
 
 u2f1 = x -> u"s"*uf1(x)
 fun2 = hchebinterp(u2f1, 0.0u"m", 1.0u"m")


### PR DESCRIPTION
Previously if the units were expressed differently, e.g. microns rather than meters, the interpolation would fail. We fix this by mapping the interpolation problem domain to the unit(less) hypercube [-1,1]^n. This also gets rid of the internal buffer in BatchFunction and handles number-to-SVector conversion through reinterpreting arrays.