### PR TITLE
Reuse function evaluation in nested Chebyshev grid

### DIFF
--- a/src/HChebInterp.jl
+++ b/src/HChebInterp.jl
@@ -153,7 +153,7 @@ BatchFunction(f, x::AbstractArray) = BatchFunction(f, similar(x, length(x)))
 _oftype(y, x) = oftype(y, x)
 _oftype(y::T, x::MVector{1,T}) where {T} = oftype(y, only(x))
 
-function evalnext!(t, valtree, funtree, searchtree, criterion::HAdaptError, f::BatchFunction, lb, ub, val, fun::ChebPoly{n,T,Td}, order, atol, rtol, norm, droptol) where {n,T,Td}
+function evalnext!(t, valtree, funtree, searchtree, criterion::HAdaptError, f::BatchFunction, lb, ub, val, fun::ChebPoly{n,T,Td}, order, atol, rtol, norm, droptol, initdiv) where {n,T,Td}
     tol = max(atol, rtol*maximum(norm, val))
 
     a = fun.lb
@@ -174,7 +174,7 @@ function evalnext!(t, valtree, funtree, searchtree, criterion::HAdaptError, f::B
         y = _oftype(ub, mb)
 
         chebpoints!(t, order, x, y)
-        nextval = batchevaluate!(f.x, f.f, t, x, y, valtree, funtree, searchtree)
+        nextval = batchevaluate!(f.x, f.f, t, order, valtree, funtree, searchtree, initdiv)
         nextfun = _chebinterp(nextval, x, y; tol=droptol)
         push!(valtree, nextval)
         push!(funtree, nextfun)
@@ -189,7 +189,7 @@ function evalnext!(t, valtree, funtree, searchtree, criterion::HAdaptError, f::B
     fill(converged, len)
 end
 
-function evalnext!(t, valtree, funtree, searchtree, criterion::SpectralError, f::BatchFunction, lb,ub, val, fun::ChebPoly{n,T,Td}, order, atol, rtol, norm, droptol) where {n,T,Td}
+function evalnext!(t, valtree, funtree, searchtree, criterion::SpectralError, f::BatchFunction, lb,ub, val, fun::ChebPoly{n,T,Td}, order, atol, rtol, norm, droptol, initdiv) where {n,T,Td}
     tol = max(atol, rtol*maximum(norm, val))
 
     a = fun.lb
@@ -209,10 +209,11 @@ function evalnext!(t, valtree, funtree, searchtree, criterion::SpectralError, f:
             tol > maximum(sum(norm, @view(fun_.coefs[idx]); dims=i))
         end
     end
+    converged = Bool[]
     dimsconverged = aredimsconverged(fun)
+    all(dimsconverged) && return converged
 
     newsize = map(v -> v ? 1 : 2, dimsconverged)
-    converged = Bool[]
     @inbounds for c in CartesianIndices(ntuple(i->Base.OneTo(newsize[i]), Val{n}())) # Val ntuple loops are unrolled
         for i = 1:n
             ma[i] = a[i]+(c[i]-1)*Δ[i]
@@ -220,9 +221,9 @@ function evalnext!(t, valtree, funtree, searchtree, criterion::SpectralError, f:
         end
         x = _oftype(lb, ma)
         y = _oftype(ub, mb)
-
+        # @show x,y
         chebpoints!(t, order, x, y)
-        nextval = batchevaluate!(f.x, f.f, t, x, y, valtree, funtree, searchtree)
+        nextval = batchevaluate!(f.x, f.f, t, order, valtree, funtree, searchtree, initdiv)
         nextfun = _chebinterp(nextval, x, y; tol=droptol)
         push!(valtree, nextval)
         push!(funtree, nextfun)
@@ -234,9 +235,52 @@ function evalnext!(t, valtree, funtree, searchtree, criterion::SpectralError, f:
 end
 
 # this function does batch evaluation while reusing already evaluated points
-function batchevaluate!(x, f, t, lb, ub, valtree, funtree, searchtree)
-    x .= vec(t)
-    return reshape(f(x), size(t))
+function batchevaluate!(x, f, t, order, valtree, funtree, searchtree, initdiv)
+    vals = similar(first(valtree))
+    idx = typeof(first(CartesianIndices(t)))[]
+    empty!(x)
+    for i in CartesianIndices(t)
+        ti = t[i]
+        next = findevaluated(ti, CartesianIndices(axes(t)), valtree, funtree, searchtree, order, initdiv)
+        if isnothing(next)
+            push!(x, ti)
+            push!(idx, i)
+        else
+            vals[i] = next
+        end
+    end
+    vals[idx] .= f(x)
+    return vals
+end
+
+function findevaluated(x, ind, valtree, funtree, searchtree, order, initdiv)
+    tol = 10*eps(one(eltype(x)))
+    for i in 1:min(initdiv^length(x), length(funtree))
+        val = valtree[i]
+        fun = funtree[i]
+        children = searchtree[i]
+        indomain(fun, x) || continue
+        while true
+            # this search will be expensive
+            next = findfirst(ind) do idx
+                norm(_chebpoint(idx - oneunit(idx), order, fun.lb, fun.ub) - x) < tol
+            end
+            if !isnothing(next)
+                # @show x next ind val[ind[next]]
+                return val[ind[next]]
+            elseif isempty(children)
+                return nothing
+            else
+                for c in children
+                    indomain(funtree[c], x) || continue
+                    val = valtree[c]
+                    fun = funtree[c]
+                    children = searchtree[c]
+                    break
+                end
+            end
+        end
+    end
 end
 
 function hchebinterp_(criterion::AbstractAdaptCriterion, f::BatchFunction, a, b, order, atol_, rtol_, norm, maxevals, initdiv, droptol)
@@ -247,10 +291,10 @@ function hchebinterp_(criterion::AbstractAdaptCriterion, f::BatchFunction, a, b,
     Δ = (b-a) / initdiv
     b1 = initdiv == 1 ? b : a+Δ
     t = Array{typeof(a),length(a)}(undef, order .+ 1)
-    chebpoints!(t, order, a, b)
+    chebpoints!(t, order, a, b1)
     resize!(f.x, length(t))
     f.x .= vec(t)
-    valtree = [reshape(f.f(f.x), size(t))]
+    valtree = [Array(reshape(f.f(f.x), size(t)))]
     funtree = [_chebinterp(valtree[1], a, b1; tol=droptol)]
     searchtree = [Int[]]
 
@@ -273,9 +317,9 @@ function hchebinterp_(criterion::AbstractAdaptCriterion, f::BatchFunction, a, b,
             y = _oftype(b, mb)
 
             chebpoints!(t, order, x, y)
-            vals = batchevaluate!(f.x, f.f, t, x, y, valtree, funtree, searchtree)
+            vals = batchevaluate!(f.x, f.f, t, order, valtree, funtree, searchtree, initdiv)
             push!(valtree, vals)
-            push!(funtree, _chebinterp(valtree[end], x, y; tol=droptol))
+            push!(funtree, _chebinterp(vals, x, y; tol=droptol))
             push!(searchtree, Int[])
         end
     end
@@ -295,7 +339,7 @@ function hchebinterp_(criterion::AbstractAdaptCriterion, f::BatchFunction, a, b,
         copy!(queue, nextqueue)
         empty!(nextqueue)
         for i in queue
-            for converged in evalnext!(t, valtree, funtree, searchtree, criterion, f, a,b, valtree[i], funtree[i], order, atol, rtol, norm, droptol)
+            for converged in evalnext!(t, valtree, funtree, searchtree, criterion, f, a,b, valtree[i], funtree[i], order, atol, rtol, norm, droptol, initdiv)
                 push!(searchtree[i], l += 1)
                 !converged && push!(nextqueue, l)
             end

--- a/test/countevals.jl
+++ b/test/countevals.jl
@@ -22,7 +22,7 @@ for ndim in 1:2
     for (criterion, numpanels) in ((HAdaptError(), 1+2^ndim+(2^ndim)^2), (SpectralError(), 1+2^ndim)),
         order in [4, 10]
         fun, numevals = hchebinterp_count(abs∘prod, -ones(ndim), ones(ndim), order=order, criterion=criterion)
-        @test numevals == numpanels*(order+1)^ndim
+        @test numevals <= numpanels*(order+1)^ndim
     end
 end
 

--- a/test/countevals.jl
+++ b/test/countevals.jl
@@ -29,5 +29,6 @@ end
 # interpolant requiring two subdivisions, asymmetrically
 for (criterion, numpanels) in ((HAdaptError(), 1+2+4+4), (SpectralError(), 1+2+2)), order in [4, 10]
     fun, numevals = hchebinterp_count(x -> min(1, abs(x)), -3, 1, order=order, criterion=criterion)
-    @test numevals == numpanels*(order+1)
+    @test numevals <= numpanels*(order+1) - (numpanels-1)*3/2
+    # in 1d we can save 1.5 evaluations per subdivided panel by reusing parent evaluations for children
 end


### PR DESCRIPTION
This pr aims to reuse interpolant evaluations due to the nested structure of the Chebyshev grid. The cost of this will be considered negligible compared to the cost of evaluating the function. In practice, this can slow down cheap examples (finish in seconds) and breaks even for more expensive ones taking O(10 seconds).

It's probably complicated to compute the number of reusable points analytically, since it depends on the order and the level of nesting, but endpoints should always be reusable. We  implement an exhaustive loop over parent nodes to check for reusability without any heuristics to make sure we reuse all possible points. This is slow and could be improved in a future release

We also add a weak test for the correct number of (reused) evaluations, (probably a weak inequality test when comparing to the number before reusing minus what you can save from shared endpoints/faces)
