### PR TITLE
add reuse keyword

### DIFF
--- a/test/countevals.jl
+++ b/test/countevals.jl
@@ -31,4 +31,6 @@ for (criterion, numpanels) in ((HAdaptError(), 1+2+4+4), (SpectralError(), 1+2+2
     fun, numevals = hchebinterp_count(x -> min(1, abs(x)), -3, 1, order=order, criterion=criterion)
     @test numevals <= numpanels*(order+1) - (numpanels-1)*3/2
     # in 1d we can save 1.5 evaluations per subdivided panel by reusing parent evaluations for children
+    fun, numevals = hchebinterp_count(x -> min(1, abs(x)), -3, 1, order=order, criterion=criterion, reuse=false)
+    @test numevals == numpanels*(order+1)
 end


### PR DESCRIPTION
adds a keyword, `reuse`, now true by default, to reuse function evaluations on the Chebyshev grid during interpolation.