### PR TITLE
Refactor

### DIFF
--- a/src/HChebInterp.jl
+++ b/src/HChebInterp.jl
@@ -35,7 +35,7 @@ function treesearch(callback, valtree, funtree, searchtree, x, initdiv)
         children = searchtree[i]
         indomain(fun, x) || continue
         r = callback(fun, val, children)
-        isnothing(r) || return r
+        r === nothing || return r
         while true
             found = false
             for c in children
@@ -48,7 +48,7 @@ function treesearch(callback, valtree, funtree, searchtree, x, initdiv)
             end
             if found
                 r = callback(fun, val, children)
-                isnothing(r) || return r
+                r === nothing || return r
                 continue
             end
             return nothing
@@ -72,7 +72,8 @@ function (p::TreePoly{N,T,V,Td,Tx})(x::SVector{N,Tx}) where {N,T,V,Td,Tx}
     r = treesearch(p.valtree, p.funtree, p.searchtree, t, p.initdiv) do fun, val, children
         isempty(children) ? convert(V, fun(t)) : nothing
     end
-    !isnothing(r) ? r : throw(ArgumentError("$x not in domain $(p.lb) to $(p.ub)"))
+    r === nothing && throw(ArgumentError("$x not in domain $(p.lb) to $(p.ub)"))
+    return r
 end
 (p::TreePoly{N,T,V,Td,Tx})(x) where {N,T,V,Td,Tx} = p(SVector{N,Tx}(x))
 


### PR DESCRIPTION
This pr refactors the code to reduce repetition. A bonus of this refactoring is that function evaluations shared between regions evaluated in the same refinement step can be reused. Typically this saves one function evaluation in the first refinement in 1d interpolation with the default settings.

Additionally, this pr creates an internal interface for `AbstractAdaptCriterion` requiring the following methods:
- `defaultorder(criterion)::Integer`: return the default order for the criterion
- `isconverged(criterion, parent, fun, ...)::Bool`: return whether or not an interpolant is converged, for the purposes of further refinement
- `nextchildrenregions!(nextregions, criterion, fun, ...)`: given a function to refine, update `nextregions` with new boxes `(x,y)` in `(fun.lb,fun.ub)` that are the refinement of the interpolant

Additionally, the simplified code creates the following internal functions:
- `treesearch(callback,...)`: used to evaluate the piecewise polynomial and search for reusable function evaluations in the piecewise tree data structure
- `evalregions!!!!(callback,...)`: used to add new interpolants to the tree data structure
- `generateregions(...)`: used to compute equispaced subdivisions based on a number of points per dimension

None of these changes is breaking, so they will be included in a patch release. These notes may be included in future documentation if others want to implement other convergence criteria.