### PR TITLE
add more convergence tests

### DIFF
--- a/test/interp.jl
+++ b/test/interp.jl
@@ -1,4 +1,4 @@
-using Test
+using Test, LinearAlgebra
 using HChebInterp
 
 ninterp = 2000
@@ -9,9 +9,11 @@ for (criterion, order) in ((SpectralError(), 15), (HAdaptError(), 6))
             atol = rtol = 1e-3
             a, b = fill(0.0,n), fill(1.0,n)
             # choose some functions to interpolate
-            f1(x) = sin(exp(sum(abs2.(x))))
-            f2(x) = exp(-sum(y ->sin(10y), x)^2)
-            for f in (f1, f2)
+            for f in (
+                x -> sin(exp(sum(abs2.(x)))),
+                x -> exp(-sum(y ->sin(10y), x)^2),
+                x -> 1e-1/(1e-2+(norm(x)-0.42)^2)*1e-1/(1e-2+(norm(x)-0.45)^2), # issue 10
+            )
                 # construct interpolant and specify atol
                 p = hchebinterp(f, a, b; criterion=criterion, order=order, atol=atol, initdiv=initdiv)
                 # check interpolation error is lower than default tolerance


### PR DESCRIPTION
In response to #10 I am adding more convergence tests with interpolation of problematic functions (multiple Lorentzians) that appear to cause interpolation with relative tolerances to fail. This is more noticeable in v1.1.0, which fails these tests, since the error tolerance is obtained from the sampled values of the parent panel, and less noticeable in v1.1.1, where the tolerance is from the samples on the current panel.

Since the tests already allow for a relative error of up to twice the requested tolerance, we might want to look for more rigorous convergence criteria for relative tolerances. In fact, v1.1.1 is not robust to changing the requested relative tolerances in the test.

Overall, the point is that absolute tolerances are more reliable than relative tolerances.