### PR TITLE
[Feature] Pass a TreePoly as initdiv

### DIFF
--- a/test/initdiv.jl
+++ b/test/initdiv.jl
@@ -25,8 +25,8 @@ g = x -> imag(1/(x+1e-2im))
 
 p1, num1 = hchebinterp_count(g, -1, 1)
 
-p2, num2 = hchebinterp_count(fi, -1, 1, initdiv=p)
+p2, num2 = hchebinterp_count(g, -1, 1, initdiv=p)
 
-p3, num3 = hchebinterp_count(fi, -1, 1, initdiv=p1)
+p3, num3 = hchebinterp_count(g, -1, 1, initdiv=p1)
 
 @test num1 > num2 > num3

--- a/test/initdiv.jl
+++ b/test/initdiv.jl
@@ -1,0 +1,32 @@
+using Test, HChebInterp
+
+function hchebinterp_count(f, args...; kws...)
+    numevals::Int = 0
+    g = if f isa BatchFunction
+        BatchFunction(f.x) do x
+            n += length(x)
+            return f.f(x)
+        end
+    else
+        x -> (numevals += 1; f(x))
+    end
+    fun = hchebinterp(g, args...; kws...)
+    return fun, numevals
+end
+
+f = x -> imag(1/(x+1e-1im))
+
+p, numa = hchebinterp_count(f, -1, 1)
+_, numb = hchebinterp_count(f, -1, 1, initdiv=2)
+
+@test numa > numb
+
+g = x -> imag(1/(x+1e-2im))
+
+p1, num1 = hchebinterp_count(g, -1, 1)
+
+p2, num2 = hchebinterp_count(fi, -1, 1, initdiv=p)
+
+p3, num3 = hchebinterp_count(fi, -1, 1, initdiv=p1)
+
+@test num1 > num2 > num3

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,3 +11,4 @@ Aqua.test_all(HChebInterp)
 @testset "precision" begin include("precision.jl") end
 @testset "units" begin include("units.jl") end
 @testset "countevals" begin include("countevals.jl") end
+@testset "initdiv" begin include("initdiv.jl") end


### PR DESCRIPTION
This pr lets the caller construct a interpolant starting from a grid which is the final grid of a previously computed interpolant. This is useful for reducing function evaluations in the case of tuning a parameter that sharpens features of the the function.